### PR TITLE
Multiple colons as delimiters can be included in the specification

### DIFF
--- a/ngx_http_cookie_prefixer_module.c
+++ b/ngx_http_cookie_prefixer_module.c
@@ -125,14 +125,21 @@ static ngx_int_t ngx_http_cookie_prefixer_rewrite_handler(ngx_http_request_t *r)
 
         u_char *prefix_start = ngx_strnstr(start, (char *)prefix->data, pos - start);
         if (prefix_start != NULL) {
-          ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: before cookie value: %s ", __func__, __LINE__,
-                        header[i].value.data);
+          int diff = prefix_start - start;
+          ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: before cookie value: %s diff:%d ", __func__,
+                        __LINE__, header[i].value.data, diff);
 
           ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: move bytes: %d ", __func__, __LINE__,
                         end - prefix_start);
-          if (start[0] == ' ') {
-            start++;
+
+          int shift = 0;
+          for (int j = 0; j < diff; j++) {
+            if (start[j] == ' ' || start[j] == ';') {
+              shift++;
+            }
           }
+          start += shift;
+
           // プレフィックスの削除
           ngx_memmove(start, prefix_start + prefix->len, ngx_strlen(prefix_start) - prefix->len);
 


### PR DESCRIPTION
下記のようにcookieの区切り文字のコロンを複数渡すことが仕様上できてしまうので、そういった場合に意図しないクッキーが後段に渡ってしまうので、そういったケースを想定した。
(As the specification allows for passing multiple colons as cookie delimiters, in such cases, unintended cookies can be passed along. This is considered in the following example.)
```
% curl -s -b'example_prefix_a=1;' -b'example_prefix_b=;' -b'example_prefix_c=;' http://localhost:1234/get -L -i
HTTP/1.1 200 OK
Server: nginx/1.25.3
Date: Thu, 21 Dec 2023 03:48:57 GMT
Content-Type: application/json
Content-Length: 249
Connection: keep-alive
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Connection": "close",
    "Cookie": "a=1;b=;c=;mp", # 意図しない値が入る
    "Host": "localhost:10080",
    "User-Agent": "curl/8.1.2"
  },
  "origin": "172.17.0.1",
  "url": "http://localhost:10080/get"
}
```


