### PR TITLE
Terminate the loop quickly.

### DIFF
--- a/ngx_http_cookie_prefixer_module.c
+++ b/ngx_http_cookie_prefixer_module.c
@@ -150,6 +150,7 @@ static ngx_int_t ngx_http_cookie_prefixer_rewrite_handler(ngx_http_request_t *r)
           ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: after cookie value: %s ", __func__, __LINE__,
                         header[i].value.data);
           pos = start;
+          end -= prefix->len;
         }
 
         start = ngx_strlchr(pos, end, ';');


### PR DESCRIPTION
cookieの探索開始位置がstart,終了位置がendなのだが、ngx_mem_moveでprefix分前に移動した後に、endも動かすと、終了条件である start <= end がより早く完了するので、prefix削除したらendも動かすようにした。

Moving the pointer of the 'end' variable as well would prevent unnecessary looping and terminate the process more efficiently.


