### PR TITLE
Short prefixes can lead to unintended behavior.

### DIFF
--- a/ngx_http_cookie_prefixer_module.c
+++ b/ngx_http_cookie_prefixer_module.c
@@ -123,23 +123,18 @@ static ngx_int_t ngx_http_cookie_prefixer_rewrite_handler(ngx_http_request_t *r)
           break;
         }
 
+        if (start[0] == ' ' || start[0] == ';') {
+          start++;
+          continue;
+        }
+
         u_char *prefix_start = ngx_strnstr(start, (char *)prefix->data, pos - start);
-        if (prefix_start != NULL) {
-          int diff = prefix_start - start;
-          ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: before cookie value: %s diff:%d ", __func__,
-                        __LINE__, header[i].value.data, diff);
+        if (prefix_start != NULL && prefix_start == start) {
+          ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: before cookie value: %s", __func__, __LINE__,
+                        header[i].value.data);
 
           ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "%s:%d: move bytes: %d ", __func__, __LINE__,
                         end - prefix_start);
-
-          int shift = 0;
-          int j     = 0;
-          for (j = 0; j < diff; j++) {
-            if (start[j] == ' ' || start[j] == ';') {
-              shift++;
-            }
-          }
-          start += shift;
 
           // プレフィックスの削除
           ngx_memmove(start, prefix_start + prefix->len, ngx_strlen(prefix_start) - prefix->len);

--- a/run_test.sh
+++ b/run_test.sh
@@ -167,7 +167,7 @@ test_many_cookies_with_fuzzing() {
   done
 }
 
-test_many_cookies_with_fuzzing_with_shortprefix() {
+test_many_cookies_with_fuzzing_and_shortprefix() {
   local query_params=""
   local values=()
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 oneTimeSetUp() {
   docker rm -f nginx-httpbin | true
-  docker run -d -p 127.0.0.1:10080:80  --name nginx-httpbin kennethreitz/httpbin
+  docker run -d -p 127.0.0.1:10080:80 --name nginx-httpbin kennethreitz/httpbin
   cp `pwd`/test/test.conf ./nginx/conf/nginx.conf
   pkill nginx
   nginx/objs/nginx -p `pwd`/nginx &
@@ -26,36 +25,36 @@ oneTimeTearDown() {
 
 test_delete_prefix() {
   # normal case
-  local result=$(curl -s -b'example_prefix_a=1' -b'not_match_prefix_b=2' http://localhost:1234/get -L -i)
+  local result=$(curl -s -b'example_prefix_a=1' -b'not_match_prefix_b=2' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1;not_match_prefix_b=2"'
   # for no value
-  local result=$(curl -s -b'example_prefix_a=1' -b'example_prefix_b=' -b'example_prefix_c=' http://localhost:1234/get -L -i)
+  local result=$(curl -s -b'example_prefix_a=1' -b'example_prefix_b=' -b'example_prefix_c=' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1;b=;c="'
   # for no value and no trailing semicolon
-  local result=$(curl -s -b'example_prefix_a=1;' -b'example_prefix_b=;' -b'example_prefix_c=;' http://localhost:1234/get -L -i)
+  local result=$(curl -s -b'example_prefix_a=1;' -b'example_prefix_b=;' -b'example_prefix_c=;' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1;;b=;;c=;"'
 }
 
 test_delete_prefix_with_header() {
   # normal case
-  local result=$(curl -s -H 'cookie: example_prefix_a=1; not_match_prefix_b=2;' http://localhost:1234/get -L -i)
+  local result=$(curl -s -H 'cookie: example_prefix_a=1; not_match_prefix_b=2;' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1; not_match_prefix_b=2;"'
   # for no value
-  local result=$(curl -s -H 'cookie: example_prefix_a=1; example_prefix_b=; example_prefix_c=;' http://localhost:1234/get -L -i)
+  local result=$(curl -s -H 'cookie: example_prefix_a=1; example_prefix_b=; example_prefix_c=;' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1; b=; c=;"'
   # for no value and no trailing semicolon
-  local result=$(curl -s -H 'cookie: example_prefix_a=1;; example_prefix_b=;; example_prefix_c=;;' http://localhost:1234/get -L -i)
+  local result=$(curl -s -H 'cookie: example_prefix_a=1;; example_prefix_b=;; example_prefix_c=;;' http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" '"a=1;; b=;; c=;;"'
 }
 
 test_append_prefix() {
-  local result=$(curl http://localhost:1234/cookies/set/foo/bar -L -i)
+  local result=$(curl http://localhost:1234/example_prefix/cookies/set/foo/bar -i)
   assertContains "$result" "$result" 'example_prefix_foo=bar; Path=/'
 }
 
 test_delete_long_cookie_with_request() {
   local long_value=$(printf 'a%.0s' {1..1000}) # 1000文字の 'a' で構成される文字列
-  local result=$(curl -s -b"example_prefix_$long_value=1" http://localhost:1234/get -L -i)
+  local result=$(curl -s -b"example_prefix_$long_value=1" http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" "$long_value=1"
 }
 
@@ -67,7 +66,7 @@ test_delete_many_cookies_with_request() {
   done
 
 
-  local result=$(curl -s "${cookies[@]}" http://localhost:1234/get -L -i)
+  local result=$(curl -s "${cookies[@]}" http://localhost:1234/example_prefix/get -i)
   assertContains "$result" "$result" "${expected/%?/}"
 }
 
@@ -77,7 +76,7 @@ test_many_cookies_with_response() {
     query_params+="name${i}=value${i}&"
   done
 
-  local result=$(curl -s -i -L "http://localhost:1234/cookies/set?$query_params")
+  local result=$(curl -s -i "http://localhost:1234/example_prefix/cookies/set?$query_params")
   for i in $(seq 1 100); do
     assertContains "$result" "$result" "Set-Cookie: example_prefix_name${i}=value${i}; Path=/"
   done
@@ -85,9 +84,107 @@ test_many_cookies_with_response() {
 
 test_large_cookie_value_with_response() {
   local large_value=$(printf 'a%.0s' {1..1000}) # 1000文字の 'a' で構成される文字列
-  local result=$(curl -s -i -L "http://localhost:1234/cookies/set?large_cookie=$large_value")
+  local result=$(curl -s -i "http://localhost:1234/example_prefix/cookies/set?large_cookie=$large_value")
   assertContains "$result" "$result" "Set-Cookie: example_prefix_large_cookie=$large_value; Path=/"
 }
 
+test_delete_many_cookies_with_fuzzing() {
+  local cookies=()
+  local expected=()
+
+  for i in {1..100}; do
+    # ランダムな文字数を生成 (例: 1〜15の範囲)
+    local len=$((RANDOM % 14 + 1))
+
+    # ロケールを C に設定して、ランダムな文字列を生成
+    local rand_str=$(LC_ALL=C dd bs=512 if=/dev/urandom count=1 | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w $len | head -n 1)
+
+    # プレフィックスをランダムに選択
+    local prefix=""
+    if (( RANDOM % 2 )); then
+      prefix="example_prefix_"
+    fi
+
+    # クッキーと期待値を配列に追加
+    cookies+=("-b" "${prefix}name${i}=${rand_str}")
+    expected+=("name${i}=${rand_str};")
+  done
+
+  # cURL コマンドの実行
+  local result=$(curl -s "${cookies[@]}" http://localhost:1234/example_prefix/get -i)
+
+  # 結果のアサーション
+  assertContains "$result" "$result" "${expected/%?/}"
+}
+
+test_delete_many_cookies_with_fuzzing_and_shortprefix() {
+  local cookies=()
+  local expected=()
+
+  for i in {1..100}; do
+    # ランダムな文字数を生成 (例: 1〜15の範囲)
+    local len=$((RANDOM % 14 + 1))
+
+    # ロケールを C に設定して、ランダムな文字列を生成
+    export LC_ALL=C
+    local rand_str=$(dd bs=512 if=/dev/urandom count=1 | tr -dc 'a-zA-Z0-9' | fold -w $len | head -n 1)
+
+    # プレフィックスをランダムに選択
+    local prefix=""
+    if (( RANDOM % 2 )); then
+      prefix="a"
+    fi
+
+    # クッキーと期待値を配列に追加
+    cookies+=("-b" "${prefix}name${i}=${rand_str}")
+    expected+=("name${i}=${rand_str};")
+  done
+
+  # cURL コマンドの実行
+  local result=$(curl -s "${cookies[@]}" http://localhost:1234/a/get -i)
+
+  # 結果のアサーション
+  assertContains "$result" "$result" "${expected/%?/}"
+}
+
+test_many_cookies_with_fuzzing() {
+  local query_params=""
+  local values=()
+
+  # ランダムな値を生成して配列に格納
+  for i in $(seq 1 100); do
+    local len=$((RANDOM % 14 + 1))
+    values[i]=$(LC_ALL=C dd bs=512 if=/dev/urandom count=1 | tr -dc 'a-zA-Z0-9' | fold -w $len | head -n 1)
+    query_params+="name${i}=${values[i]}&"
+  done
+
+  # cURL コマンドの実行
+  local result=$(curl -i "http://localhost:1234/example_prefix/cookies/set?$query_params")
+
+  # 結果の検証
+  for i in $(seq 1 100); do
+    assertContains "$result" "$result" "Set-Cookie: example_prefix_name${i}=${values[i]}; Path=/"
+  done
+}
+
+test_many_cookies_with_fuzzing_with_shortprefix() {
+  local query_params=""
+  local values=()
+
+  # ランダムな値を生成して配列に格納
+  for i in $(seq 1 100); do
+    local len=$((RANDOM % 14 + 1))
+    values[i]=$(LC_ALL=C dd bs=512 if=/dev/urandom count=1 | tr -dc 'a-zA-Z0-9' | fold -w $len | head -n 1)
+    query_params+="name${i}=${values[i]}&"
+  done
+
+  # cURL コマンドの実行
+  local result=$(curl -i "http://localhost:1234/a/cookies/set?$query_params")
+
+  # 結果の検証
+  for i in $(seq 1 100); do
+    assertContains "$result" "$result" "Set-Cookie: aname${i}=${values[i]}; Path=/"
+  done
+}
 
 . tmp/shunit2/shunit2

--- a/test/test.conf
+++ b/test/test.conf
@@ -11,12 +11,29 @@ http {
     server {
         listen       127.0.0.1:1234;
         server_name  localhost;
-        location /{
+        location / {
           proxy_connect_timeout 10;
           proxy_send_timeout 10;
           proxy_read_timeout 60;
           proxy_detach_cookie_prefix example_prefix_;
-          proxy_pass http://localhost:10080;
+          proxy_pass http://localhost:10080/;
+        }
+
+
+        location /example_prefix {
+          proxy_connect_timeout 10;
+          proxy_send_timeout 10;
+          proxy_read_timeout 60;
+          proxy_detach_cookie_prefix example_prefix_;
+          proxy_pass http://localhost:10080/;
+        }
+
+        location /a {
+          proxy_connect_timeout 10;
+          proxy_send_timeout 10;
+          proxy_read_timeout 60;
+          proxy_detach_cookie_prefix a;
+          proxy_pass http://localhost:10080/;
         }
     }
 }


### PR DESCRIPTION
I revised the comparison conditions for prefixes because setting a very short prefix like 'a' can lead to unintended behavior.